### PR TITLE
Adds mysql client (5.6).

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER João Fidalgo <joao.fidalgo@outlook.com>
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
- apt-get install -y curl lib32gcc1
+ apt-get install -y curl lib32gcc1 mysql-client-5.6
 
 RUN mkdir -p /opt/steamcmd && \
  curl -s http://media.steampowered.com/installer/steamcmd_linux.tar.gz | tar -vxz -C /opt/steamcmd


### PR DESCRIPTION
Sourcemod can use mysql dbs. But for that, we need the client-libs, from what I understand. :)
